### PR TITLE
Fix NH fallback geocoding check

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -153,7 +153,7 @@ def lookup():
     if latf is None or lonf is None:
         addr = _sanitize_address(raw_addr)
         latf, lonf, town_upper = _geocode_census(addr)
-        if latf is None or lonf is None and " NH" not in addr.upper():
+        if (latf is None or lonf is None) and " NH" not in addr.upper():
             latf, lonf, town_upper = _geocode_census(addr + ", NH")
         if latf is None or lonf is None:
             return jsonify({"error": "could not geocode"}), 422


### PR DESCRIPTION
## Summary
- ensure the NH geocoding fallback only triggers when geocoding fails

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d99113621c8331bf63b64f5ccd0998